### PR TITLE
only delete/reset users that have logged in at least once

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Users are deleted when they did not log into their account within the given number of days. This will also delete all files of the affected users.
 
 > ![Screenshot of the admin settings](docs/screenshot.png)
+
+## Users who did not log in
+
+By default users who have not logged in will be spared from removal. To also take them into consideration, set the conflig flag accordingly:
+
+`occ config:app:set user_retention keep_users_without_login --value=no`

--- a/lib/BackgroundJob/ExpireUsers.php
+++ b/lib/BackgroundJob/ExpireUsers.php
@@ -93,7 +93,7 @@ class ExpireUsers extends TimedJob {
 		$excludedGroups = json_decode($excludedGroups, true);
 		$this->excludedGroups = \is_array($excludedGroups) ? $excludedGroups : [];
 
-		$this->userManager->callForAllUsers(function(IUser $user) {
+		$this->userManager->callForSeenUsers(function(IUser $user) {
 			$maxLastLogin = $this->userMaxLastLogin;
 			if ($user->getBackend() instanceof UserBackend) {
 				$maxLastLogin = $this->guestMaxLastLogin;
@@ -117,6 +117,11 @@ class ExpireUsers extends TimedJob {
 		if ($createdAt === 0) {
 			// Set "now" as created at timestamp for the user.
 			$this->setCreatedAt($user, $this->timeFactory->getTime());
+			return false;
+		}
+
+		if ($user->getLastLogin() === 0) {
+			// no need for deletion when no user dir was initialized
 			return false;
 		}
 

--- a/lib/BackgroundJob/ExpireUsers.php
+++ b/lib/BackgroundJob/ExpireUsers.php
@@ -54,6 +54,8 @@ class ExpireUsers extends TimedJob {
 	protected $userMaxLastLogin = 0;
 	protected $guestMaxLastLogin = 0;
 	protected $excludedGroups = [];
+	/** @var bool*/
+	protected $keepUsersWithoutLogin = true;
 
 	/** @var IServerContainer */
 	private $server;
@@ -89,11 +91,13 @@ class ExpireUsers extends TimedJob {
 			$this->guestMaxLastLogin = $now->sub(new \DateInterval('P' . $guestDays . 'D'))->getTimestamp();
 		}
 
+		$this->keepUsersWithoutLogin = $this->config->getAppValue('user_retention', 'keep_users_without_login', 'yes') === 'yes';
+
 		$excludedGroups = $this->config->getAppValue('user_retention', 'excluded_groups', '["admin"]');
 		$excludedGroups = json_decode($excludedGroups, true);
 		$this->excludedGroups = \is_array($excludedGroups) ? $excludedGroups : [];
 
-		$this->userManager->callForSeenUsers(function(IUser $user) {
+		$handler = function(IUser $user) {
 			$maxLastLogin = $this->userMaxLastLogin;
 			if ($user->getBackend() instanceof UserBackend) {
 				$maxLastLogin = $this->guestMaxLastLogin;
@@ -105,7 +109,12 @@ class ExpireUsers extends TimedJob {
 				}
 				$user->delete();
 			}
-		});
+		};
+		if($this->keepUsersWithoutLogin) {
+			$this->userManager->callForSeenUsers($handler);
+		} else {
+			$this->userManager->callForAllUsers($handler);
+		}
 	}
 
 	protected function shouldExpireUser(IUser $user, int $maxLastLogin): bool {
@@ -120,7 +129,7 @@ class ExpireUsers extends TimedJob {
 			return false;
 		}
 
-		if ($user->getLastLogin() === 0) {
+		if ($this->keepUsersWithoutLogin && $user->getLastLogin() === 0) {
 			// no need for deletion when no user dir was initialized
 			return false;
 		}


### PR DESCRIPTION
> The “User Retention” App should only process those accounts where users have already logged in and have a data directory.

Login initialized data dir, so that's sufficient to check. I also switched from cycling to all users to cycling through seen users. 