### PR TITLE
improve logging

### DIFF
--- a/lib/BackgroundJob/ExpireUsers.php
+++ b/lib/BackgroundJob/ExpireUsers.php
@@ -107,7 +107,12 @@ class ExpireUsers extends TimedJob {
 				if($user->getBackendClassName() === 'LDAP' && !$this->prepareLDAPUser($user)) {
 					return;
 				}
-				$user->delete();
+
+				if ($user->delete()) {
+					$this->server->getLogger()->info('User deleted: ' . $user->getUID(), [
+						'app' => 'user_retention',
+					]);
+				}
 			}
 		};
 


### PR DESCRIPTION
explicit log message from the user_retention app when a user was deleted due to the expire rules to distinguish it from normal user deletions

I think this makes sense in general to make it more transparent when the app deletes a user.