### PR TITLE
Loglevel "warning" causes cronjob to Log userUIDs on every cron run

### DIFF
--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -130,7 +130,7 @@ class RetentionService {
 	}
 
 	public function executeRetentionPolicy(IUser $user): ?bool {
-		$this->logger->warning($user->getUID());
+		$this->logger->debug($user->getUID());
 		$skipIfNewerThan = $this->userMaxLastLogin;
 		$policyDays = $this->userDays;
 		if ($user->getBackend() instanceof GuestUserBackend) {


### PR DESCRIPTION
Everytime the cronjob runs it outputs all userUIDs like this:

`{"reqId":"xxxxxxxxxxxxxxxxxxxx","level":2,"time":"2023-02-20T14:21:23+00:00","remoteAddr":"","user":"--","app":"user_retention","method":"","url":"--","message":"user42","userAgent":"--","version":"25.0.3.2","data":{"app":"user_retention"}}
{"reqId":"xxxxxxxxxxxxxxxxxxxx","level":2,"time":"2023-02-20T14:21:23+00:00","remoteAddr":"","user":"--","app":"user_retention","method":"","url":"--","message":"admin","userAgent":"--","version":"25.0.3.2","data":{"app":"user_retention"}}
{"reqId":"xxxxxxxxxxxxxxxxxxxx","level":2,"time":"2023-02-20T14:21:23+00:00","remoteAddr":"","user":"--","app":"user_retention","method":"","url":"--","message":"user23","userAgent":"--","version":"25.0.3.2","data":{"app":"user_retention"}}
`
Nextclouds default loglevel is 2 (WARN) so this is always printed. I don't think this output is relevant for normal use.
A more reasonable loglevel would be "debug" as this output is at most relevant for development.
