### PR TITLE
Avoid immediate re-expiration of accounts 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,5 +15,6 @@
 - Jonas <jonas@freesources.org>
 - Morris Jobke <hey@morrisjobke.de>
 - rakekniven <2069590+rakekniven@users.noreply.github.com>
+- Salvatore Martire <salvatore.martire@nextcloud.com>
 - Sascha Wiswedel <sascha.wiswedel@nextcloud.com>
 - Vincent Petry <vincent@nextcloud.com>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -7,10 +7,12 @@ declare(strict_types=1);
  */
 namespace OCA\UserRetention\AppInfo;
 
+use OCA\UserRetention\Listeners\UserChangedListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserChangedEvent;
 use OCP\Util;
 
 class Application extends App implements IBootstrap {
@@ -20,6 +22,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerEventListener(UserChangedEvent::class, UserChangedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Listeners/UserChangedListener.php
+++ b/lib/Listeners/UserChangedListener.php
@@ -21,9 +21,9 @@ use Psr\Log\LoggerInterface;
 class UserChangedListener implements IEventListener {
 
 	public function __construct(
-		public LoggerInterface $logger,
-		public IConfig $config,
-		public ITimeFactory $timeFactory,
+		protected LoggerInterface $logger,
+		protected IConfig $config,
+		protected ITimeFactory $timeFactory,
 	) {
 	}
 

--- a/lib/Listeners/UserChangedListener.php
+++ b/lib/Listeners/UserChangedListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\UserRetention\Listeners;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+use OCP\User\Events\UserChangedEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @template-implements IEventListener<Event&UserChangedEvent>
+ */
+class UserChangedListener implements IEventListener {
+
+	public function __construct(
+		public LoggerInterface $logger,
+		public IConfig $config,
+		public ITimeFactory $timeFactory,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof UserChangedEvent)) {
+			return;
+		}
+
+		if ($event->getFeature() === 'enabled') {
+			$this->handleEnabledChange($event);
+		}
+	}
+
+	private function handleEnabledChange(UserChangedEvent $event): void {
+		$oldValue = $event->getOldValue();
+		$newValue = $event->getValue();
+		if ($oldValue === false && $newValue === true) {
+			$this->config->setUserValue(
+				$event->getUser()->getUID(),
+				'user_retention',
+				'user_reenabled_at',
+				(string)$this->timeFactory->getTime()
+			);
+		}
+	}
+}

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -157,6 +157,7 @@ class RetentionService {
 				$this->logger->debug('Account already disabled, continuing with potential deletion: ' . $user->getUID());
 			} catch (SkipUserException $e) {
 				// Not disabling yet, continue with checking deletion
+				$this->logger->debug("Disable: {$e->getMessage()}", $e->getLogParameters());
 			}
 		} else {
 			$this->logger->debug('No account disabling policy enabled for account: ' . $user->getUID());
@@ -183,6 +184,7 @@ class RetentionService {
 				return true;
 			} catch (SkipUserException $e) {
 				// Not deleting yet, continue with checking reminders
+				$this->logger->debug("Delete: {$e->getMessage()}", $e->getLogParameters());
 			}
 		} else {
 			$this->logger->debug('No account retention policy enabled for account: ' . $user->getUID());
@@ -202,7 +204,7 @@ class RetentionService {
 
 				$this->sendReminder($user, $lastActivity, $policyDays, $policyDaysDisable);
 			} catch (SkipUserException $e) {
-				$this->logger->debug($e->getMessage(), $e->getLogParameters());
+				$this->logger->debug("Reminder: {$e->getMessage()}", $e->getLogParameters());
 				continue;
 			}
 		}

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -223,11 +223,12 @@ class RetentionService {
 		$discoveryTimestamp = $this->skipUserBasedOnDiscovery($user);
 		$lastWebLogin = $user->getLastLogin();
 		$authTokensLastActivity = $this->getAuthTokensLastActivity($user);
+		$userReenabledTimestamp = (int)$this->config->getUserValue($user->getUID(), 'user_retention', 'user_reenabled_at', 0);
 
 		if ($authTokensLastActivity === null) {
-			$lastAction = max($discoveryTimestamp, $lastWebLogin);
+			$lastAction = max($discoveryTimestamp, $lastWebLogin, $userReenabledTimestamp);
 		} else {
-			$lastAction = max($discoveryTimestamp, $lastWebLogin, $authTokensLastActivity);
+			$lastAction = max($discoveryTimestamp, $lastWebLogin, $authTokensLastActivity, $userReenabledTimestamp);
 		}
 
 		if ($this->keepUsersWithoutLogin && $lastAction === 0) {

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -157,7 +157,7 @@ class RetentionService {
 				$this->logger->debug('Account already disabled, continuing with potential deletion: ' . $user->getUID());
 			} catch (SkipUserException $e) {
 				// Not disabling yet, continue with checking deletion
-				$this->logger->debug("Disable: {$e->getMessage()}", $e->getLogParameters());
+				$this->logger->debug('Disable: ' . $e->getMessage(), $e->getLogParameters());
 			}
 		} else {
 			$this->logger->debug('No account disabling policy enabled for account: ' . $user->getUID());
@@ -184,7 +184,7 @@ class RetentionService {
 				return true;
 			} catch (SkipUserException $e) {
 				// Not deleting yet, continue with checking reminders
-				$this->logger->debug("Delete: {$e->getMessage()}", $e->getLogParameters());
+				$this->logger->debug('Delete: ' . $e->getMessage(), $e->getLogParameters());
 			}
 		} else {
 			$this->logger->debug('No account retention policy enabled for account: ' . $user->getUID());
@@ -204,7 +204,7 @@ class RetentionService {
 
 				$this->sendReminder($user, $lastActivity, $policyDays, $policyDaysDisable);
 			} catch (SkipUserException $e) {
-				$this->logger->debug("Reminder: {$e->getMessage()}", $e->getLogParameters());
+				$this->logger->debug('Reminder: ' . $e->getMessage(), $e->getLogParameters());
 				continue;
 			}
 		}

--- a/tests/Listeners/UserChangedListenerTest.php
+++ b/tests/Listeners/UserChangedListenerTest.php
@@ -18,9 +18,9 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class UserChangedListenerTest extends TestCase {
-	private MockObject&LoggerInterface $logger;
-	private MockObject&IConfig $config;
-	private MockObject&ITimeFactory $timeFactory;
+	private LoggerInterface&MockObject $logger;
+	private IConfig&MockObject $config;
+	private ITimeFactory&MockObject $timeFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -30,9 +30,9 @@ class UserChangedListenerTest extends TestCase {
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 	}
 
-	public function testUserEnabledShouldTriggerUserReenabledAtUpdate() {
+	public function testUserEnabledShouldTriggerUserReenabledAtUpdate(): void {
 		$time = time();
-		$uid = '100';
+		$uid = 'user';
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getUID')->willReturn($uid);
 		$this->timeFactory->expects($this->once())->method('getTime')->willReturn($time);
@@ -48,7 +48,7 @@ class UserChangedListenerTest extends TestCase {
 		$listener->handle($event);
 	}
 
-	public function testHandleShouldNotHandleOtherEvents() {
+	public function testHandleShouldNotHandleOtherEvents(): void {
 		$event = $this->createMock(UserCreatedEvent::class);
 		$this->config->expects($this->never())->method('setUserValue');
 
@@ -56,7 +56,7 @@ class UserChangedListenerTest extends TestCase {
 		$listener->handle($event);
 	}
 
-	public function testHandleShouldOnlyHandleEnabledFeature() {
+	public function testHandleShouldOnlyHandleEnabledFeature(): void {
 		$event = $this->createMock(UserChangedEvent::class);
 		$event->expects($this->once())->method('getFeature')->willReturn('otherFeature');
 		$this->config->expects($this->never())->method('setUserValue');
@@ -65,7 +65,7 @@ class UserChangedListenerTest extends TestCase {
 		$listener->handle($event);
 	}
 
-	public function testDisabledUserShouldNotTriggerUserReenabledAtUpdate() {
+	public function testDisabledUserShouldNotTriggerUserReenabledAtUpdate(): void {
 		$this->config->expects($this->never())->method('setUserValue');
 
 		$event = $this->createMock(UserChangedEvent::class);

--- a/tests/Listeners/UserChangedListenerTest.php
+++ b/tests/Listeners/UserChangedListenerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\UserRetention\Tests;
+
+use OCA\UserRetention\Listeners\UserChangedListener;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use OCP\User\Events\UserCreatedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class UserChangedListenerTest extends TestCase {
+	private MockObject&LoggerInterface $logger;
+	private MockObject&IConfig $config;
+	private MockObject&ITimeFactory $timeFactory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+	}
+
+	public function testUserEnabledShouldTriggerUserReenabledAtUpdate() {
+		$time = time();
+		$uid = '100';
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->once())->method('getUID')->willReturn($uid);
+		$this->timeFactory->expects($this->once())->method('getTime')->willReturn($time);
+		$this->config->expects($this->once())->method('setUserValue')->with($uid, 'user_retention', 'user_reenabled_at', $time);
+
+		$event = $this->createMock(UserChangedEvent::class);
+		$event->expects($this->once())->method('getUser')->willReturn($user);
+		$event->expects($this->once())->method('getFeature')->willReturn('enabled');
+		$event->expects($this->once())->method('getOldValue')->willReturn(false);
+		$event->expects($this->once())->method('getValue')->willReturn(true);
+
+		$listener = new UserChangedListener($this->logger, $this->config, $this->timeFactory);
+		$listener->handle($event);
+	}
+
+	public function testHandleShouldNotHandleOtherEvents() {
+		$event = $this->createMock(UserCreatedEvent::class);
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$listener = new UserChangedListener($this->logger, $this->config, $this->timeFactory);
+		$listener->handle($event);
+	}
+
+	public function testHandleShouldOnlyHandleEnabledFeature() {
+		$event = $this->createMock(UserChangedEvent::class);
+		$event->expects($this->once())->method('getFeature')->willReturn('otherFeature');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$listener = new UserChangedListener($this->logger, $this->config, $this->timeFactory);
+		$listener->handle($event);
+	}
+
+	public function testDisabledUserShouldNotTriggerUserReenabledAtUpdate() {
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$event = $this->createMock(UserChangedEvent::class);
+		$event->expects($this->once())->method('getFeature')->willReturn('enabled');
+		$event->expects($this->once())->method('getOldValue')->willReturn(true);
+		$event->expects($this->once())->method('getValue')->willReturn(false);
+
+		$listener = new UserChangedListener($this->logger, $this->config, $this->timeFactory);
+		$listener->handle($event);
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where a user that has been inactive for a while, had their account disabled automatically by the background-job in this app and that has been re-enabled by an admin would get their account disabled again, if they would not log-in before the next run of the background-job. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)