### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d93fc10fea3db4b4896e37db312fae685cff54c4"
+                "reference": "6560c73511beef0def4a2f7f9442c2ea66376af9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d93fc10fea3db4b4896e37db312fae685cff54c4",
-                "reference": "d93fc10fea3db4b4896e37db312fae685cff54c4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6560c73511beef0def4a2f7f9442c2ea66376af9",
+                "reference": "6560c73511beef0def4a2f7f9442c2ea66376af9",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2025-12-02T00:53:40+00:00"
+            "time": "2026-02-06T01:05:41+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency