### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6560c73511beef0def4a2f7f9442c2ea66376af9"
+                "reference": "0db5adfe3340fc18431251fbe90a1d480600a837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6560c73511beef0def4a2f7f9442c2ea66376af9",
-                "reference": "6560c73511beef0def4a2f7f9442c2ea66376af9",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0db5adfe3340fc18431251fbe90a1d480600a837",
+                "reference": "0db5adfe3340fc18431251fbe90a1d480600a837",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2026-02-06T01:05:41+00:00"
+            "time": "2026-02-20T01:07:05+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency