### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "14169373352be5869ff281c9391487ef8514c97e"
+                "reference": "b8cc0f659d50013628ce93dd1a07222618c474f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/14169373352be5869ff281c9391487ef8514c97e",
-                "reference": "14169373352be5869ff281c9391487ef8514c97e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b8cc0f659d50013628ce93dd1a07222618c474f4",
+                "reference": "b8cc0f659d50013628ce93dd1a07222618c474f4",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2026-03-27T01:17:37+00:00"
+            "time": "2026-04-28T01:53:21+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency