### PR TITLE
revert: feat(deps): Add Nextcloud 35 support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 * ⛔ Exclude accounts based on group memberships (default: admin group)
 * 🔑 Exclude accounts that never logged in (default: enabled)
 ]]></description>
-	<version>1.18.0-dev.0</version>
+	<version>1.17.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 	<namespace>UserRetention</namespace>
@@ -31,7 +31,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/user_retention/main/docs/screenshot.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="30" max-version="35" />
+		<nextcloud min-version="30" max-version="34" />
 	</dependencies>
 
 	<background-jobs>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user_retention",
-  "version": "1.18.0-dev.0",
+  "version": "1.17.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user_retention",
-      "version": "1.18.0-dev.0",
+      "version": "1.17.0-dev.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user_retention",
-  "version": "1.18.0-dev.0",
+  "version": "1.17.0-dev.0",
   "private": true,
   "description": "Deletes users that did not log in in the last days.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
- Reverts: https://github.com/nextcloud/user_retention/pull/1027/
- To simplify the release for Nextcloud 34: 
  - https://github.com/nextcloud/user_retention/pull/1033
- To be brought back after the v1.17.0 release